### PR TITLE
Added @click handler to buttons

### DIFF
--- a/lovelace-multiline-text-input-card.js
+++ b/lovelace-multiline-text-input-card.js
@@ -131,7 +131,7 @@
 
 		renderButton(key) {
 			return this.state.buttons[key]
-				? html`<div class="button" title="${this.state.hints[key]}" id="button-${key}" @tap="${() => { if(this.callAction(key) !== false) { this.callService(key); }}}"><ha-icon icon="${this.state.icons[key]}"></ha-icon></div>`
+				? html`<div class="button" title="${this.state.hints[key]}" id="button-${key}" @tap="${() => { if(this.callAction(key) !== false) { this.callService(key); }}}" @click="${() => { if(this.callAction(key) !== false) { this.callService(key); }}}"><ha-icon icon="${this.state.icons[key]}"></ha-icon></div>`
 				: null;
 		}
 


### PR DESCRIPTION
As mentioned in issue https://github.com/faeibson/lovelace-multiline-text-input-card/issues/9, mouse clicks on action buttons are no longer working for newer versions of HA. So I duplicated `@tap` event handler so the buttons will work with `@click` events too.